### PR TITLE
Multiple Filter Support

### DIFF
--- a/jquery.transform.js
+++ b/jquery.transform.js
@@ -128,15 +128,28 @@ if ( supportProperty && supportProperty != propertyName ) {
 
 			// rotate, scale and skew
 			if ( !animate || animate.M ) {
-				elem.style.filter = elem.currentStyle['filter'] + [
-					" progid:DXImageTransform.Microsoft.Matrix(",
-						"M11="+value[0]+",",
-						"M12="+value[2]+",",
-						"M21="+value[1]+",",
-						"M22="+value[3]+",",
-						"SizingMethod='auto expand'",
-					")"
-				].join('');
+				var elemFilter = elem.currentStyle['filter'];
+				
+				if(~elemFilter.indexOf('Matrix')) {
+					var elemMatrix = elem.filters["DXImageTransform.Microsoft.Matrix"];
+					
+					elemMatrix.M11 = value[0];
+					elemMatrix.M12 = value[2];
+					elemMatrix.M21 = value[1];
+					elemMatrix.M22 = value[3];
+					elemMatrix.SizingMethod = "auto expand";
+				} else {
+					elem.style.filter = [
+						elemFilter === "" ? "" : elemFilter + " ",
+						"progid:DXImageTransform.Microsoft.Matrix(",
+							"M11="+value[0]+",",
+							"M12="+value[2]+",",
+							"M21="+value[1]+",",
+							"M22="+value[3]+",",
+							"SizingMethod='auto expand'",
+						")"
+					].join('');
+				}
 
 				// center the transform origin, from pbakaus's Transformie http://github.com/pbakaus/transformie
 				if ( (centerOrigin = $.transform.centerOrigin) ) {

--- a/jquery.transform.js
+++ b/jquery.transform.js
@@ -24,7 +24,7 @@
 var div = document.createElement('div'),
 	divStyle = div.style,
 	propertyName = 'transform',
-	suffix = propertyName[0].toUpperCase() + propertyName.slice(1),
+	suffix = 'Transform', // IE<8 cannot access string as array as follows: propertyName[0].toUpperCase() + propertyName.slice(1),
 	testProperties = [
 		'O' + suffix,
 		'ms' + suffix,
@@ -122,6 +122,7 @@ if ( supportProperty ) {
 			return "matrix(" + matrix + ")";
 		},
 		set: function( elem, value ) {
+			elem.style.zoom = '1'; // Must add hasLayout to work in IE<8
 			value = matrix(value);
 			elem.style.filter = [
 				"progid:DXImageTransform.Microsoft.Matrix(",

--- a/jquery.transform.js
+++ b/jquery.transform.js
@@ -122,11 +122,13 @@ if ( supportProperty && supportProperty != propertyName ) {
 			return "matrix(" + matrix + ")";
 		},
 		set: function( elem, value, animate ) {
+			elem.style.zoom = '1'; // Give hasLayout to elements that don't have it
+
 			value = matrix(value);
 
 			// rotate, scale and skew
-			if ( !animate || animate.M ) {				
-				elem.style.filter = elem.currentStyle['filter'] + [ // Make Matrix additive
+			if ( !animate || animate.M ) {
+				elem.style.filter = elem.currentStyle['filter'] + [
 					" progid:DXImageTransform.Microsoft.Matrix(",
 						"M11="+value[0]+",",
 						"M12="+value[2]+",",


### PR DESCRIPTION
In addition to throwing in .zoom, the fork also grants the ability for an element to possess previously-existing filters (such as Gradient and Alpha).  In the main codebase, the Matrix will erase other filters.
