### PR TITLE
Fixed invalid package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "CSS3",
         "cssHooks"
     ],
-    "homepage": "https://github.com/louisremi/jquery.transform.js"
+    "homepage": "https://github.com/louisremi/jquery.transform.js",
     "files": [
         "jquery.transform2d.js",
         "jquery.transform3d.js"


### PR DESCRIPTION
Hi, 

we [@VersionEye](https://www.versioneye.com/) are currently analysing quality of Bower packages and found that your library didnt pass JSONLint. 

I fixed that small typo and it's okay now.
